### PR TITLE
build(pip): use Python 3.12

### DIFF
--- a/.github/workflows/pip-compile-upgrade.yml
+++ b/.github/workflows/pip-compile-upgrade.yml
@@ -10,6 +10,7 @@ jobs:
     uses: coatl-dev/workflows/.github/workflows/pip-compile-upgrade.yml@v4
     with:
       path: requirements.txt
+      python-version: '3.12'
     secrets:
       gh-token: ${{ secrets.COATL_BOT_GH_TOKEN }}
       gpg-sign-passphrase: ${{ secrets.COATL_BOT_GPG_PASSPHRASE }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,11 +7,15 @@ on:
 
 jobs:
   tox:
-    uses: coatl-dev/workflows/.github/workflows/tox.yml@v4
+    uses: coatl-dev/workflows/.github/workflows/tox-envs.yml@v4
+    with:
+      python-versions: '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'
 
   pypi-publish:
-    needs: 
+    needs:
       - tox
     uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v4
+    with:
+      python-version: '3.12'
     secrets:
       password: ${{ secrets.PYPI_API_TOKEN_IGNITION_API_STUBS }}


### PR DESCRIPTION
for:
- building and pushing to PyPI
- upgrading requirements file (pip-compile)
